### PR TITLE
max finder based at parabolic approximation

### DIFF
--- a/code/functions.py
+++ b/code/functions.py
@@ -60,6 +60,17 @@ def distortion(normalised, shape):
 def pulse_height(samples):
     return max(samples)-min(samples)
 
+def pulse_height_q2(m_idx, samples):
+    if m_idx == 0 or m_idx == len(samples)-1:
+    	return max(samples)-min(samples)
+    x_parab = [m_idx-1, m_idx, m_idx+1]
+    y_parab = [samples[m_idx-1], samples[m_idx], samples[m_idx+1]]
+    parab_coeff = np.polyfit(x_parab, y_parab, 2)
+    # x_max = -b/2a
+    x_extremum = 0 - parab_coeff[1] / parab_coeff[0] / 2.
+    y_extremum = parab_coeff[0] * x_extremum * x_extremum + parab_coeff[1] * x_extremum + parab_coeff[2]
+    return y_extremum-min(samples)
+
     # Function to create bin_array 
 def create_bin_array(start, stop, bin_size):
     return np.arange(start, stop, bin_size)

--- a/code/pulsecatcher.py
+++ b/code/pulsecatcher.py
@@ -106,7 +106,9 @@ def pulsecatcher(mode):
 			# Function calculates pulse height of all samples 
 			height = fn.pulse_height(samples)
 			# Filter out noise
-			if samples[peak] == max(samples) and height > threshold and samples[peak] < 32768:
+			if (samples[peak] == max(samples) 
+					and (height := fn.pulse_height_q2(peak, samples)) > threshold 
+					and samples[peak] < 32768):
 				# Function normalises sample to zero and converts to integer
 				normalised = fn.normalise_pulse(samples)
 				# Compares pulse to sample and calculates distortion number


### PR DESCRIPTION
Replace max finder from simple max(samples) by max from parabola via sample[max-1],sample[max],sample[max+1]
Some optimization (height calculated only if pulse was properly positioned)

I know that pulse shape isn't parabolic, it depends of hardware,  typically they pretends to be "gaussian", but parabolic approximation seems to be better than "plain max".
In my case (pulse len=21 sample, not symmetric shape)  i got small resolution improvement (8.0% -> 7.7%) without extra cpu load. 
<img width="391" alt="shape1" src="https://github.com/ssesselmann/impulse/assets/581358/f1aa006a-a01e-46c2-aa60-aca24f164e87">
