### PR TITLE
GS-MAX/nano calibration from hardware; debug pulse shape decoding

### DIFF
--- a/code/functions.py
+++ b/code/functions.py
@@ -417,8 +417,8 @@ def export_csv(filename):
     with open(f'{data_directory}/{filename}') as f:
         data = json.load(f)
     # Extract data from json file
-    spectrum     = data["resultData"]["energySpectrum"]["spectrum"]
-    coefficients = data["resultData"]["energySpectrum"]["energyCalibration"]["coefficients"]
+    spectrum     = data["data"][0]["resultData"]["energySpectrum"]["spectrum"]
+    coefficients = data["data"][0]["resultData"]["energySpectrum"]["energyCalibration"]["coefficients"]
     # Make sure coefficient[2] is not negative
     if coefficients[2] <= 0:
         coefficients[2] = 0
@@ -439,7 +439,7 @@ def update_coeff(filename, coeff_1, coeff_2, coeff_3):
     with open(f'{data_directory}/{filename}.json') as f:
         data = json.load(f)
 
-    coefficients    = data["resultData"]["energySpectrum"]["energyCalibration"]["coefficients"]
+    coefficients    = data["data"][0]["resultData"]["energySpectrum"]["energyCalibration"]["coefficients"]
     coefficients[0] = coeff_3
     coefficients[1] = coeff_2
     coefficients[2] = coeff_1

--- a/code/shproto/__init__.py
+++ b/code/shproto/__init__.py
@@ -9,7 +9,7 @@ BUFFER_SIZE = 4096    # Maximum buffer size
 
 # Define constant values for different modes
 MODE_HISTOGRAM = 0x01
-MODE_OSCILO = 0x02
+MODE_PULSE = 0x02
 MODE_TEXT = 0x03
 MODE_STAT = 0x04
 MODE_BOOTLOADER = 0xF3  # Bootloader mode

--- a/code/tab2.py
+++ b/code/tab2.py
@@ -721,7 +721,7 @@ def play_sound(n_clicks, filename2):
         if os.path.exists(histogram2):
                 with open(histogram2, "r") as f:
                     data_2     = json.load(f)
-                    spectrum_2 = data_2["resultData"]["energySpectrum"]["spectrum"]
+                    spectrum_2 = data_2["data"][0]["resultData"]["energySpectrum"]["spectrum"]
 
         gc = fn.gaussian_correl(spectrum_2, 1)
 


### PR DESCRIPTION
GS-MAX/nano is capable to hold calibration data, and AtomSpectra(andriod) or BqMon(win) can read/update calibration data (max polynom order up to 5)
Now impulse can read calibration data from hardware and build new order 2  polynom.
How to use: 
- select tab2
- push start
- select "read calibration" at "serial command"
- switch to other tab (tab3/tab1) and back to tab2 (don't touch other controls before tab switching)
- you can see updated calibration (and device serial number at json data)
Sorry I don't know how to update calibration bins/energies from callback so "strange" manual tab switching is required

basic decoding of output of pulse shape ("-mode 2")